### PR TITLE
Fixed the sha256sum

### DIFF
--- a/open-usp-tukubai.rb
+++ b/open-usp-tukubai.rb
@@ -3,7 +3,7 @@ class OpenUspTukubai < Formula
   homepage "https://uec.usp-lab.com/TUKUBAI/CGI/TUKUBAI.CGI?POMPA=DOWNLOAD"
   url "https://uec.usp-lab.com/TUKUBAI/DOWNLOAD/open-usp-tukubai-20221028.tar.bz2"
   version "20221028"
-  sha256 "6c6580198128deb27dcb3f110d2d419e580fa8664c57a918ed839dff655b26e4"
+  sha256 "abb42f9e60f8af809b346ef52dddd3ce4ac01b5ffededcc63afef86f94e60d7e"
   # head "https://github.com/usp-engineers-community/Open-usp-Tukubai.git", branch: "master"
 
   def install


### PR DESCRIPTION
It seems the checksum is wrong (or perhaps out dated).

I obtained the sha256sum as follows.

```sh
$ curl https://uec.usp-lab.com/TUKUBAI/DOWNLOAD/open-usp-tukubai-20221028.tar.bz2 2> /dev/null | sha256sum
abb42f9e60f8af809b346ef52dddd3ce4ac01b5ffededcc63afef86f94e60d7e  -
```